### PR TITLE
feat: add application cancellation flow with status-based validation …

### DIFF
--- a/prisma/migrations/20251204155411_add_cancellation_fields/migration.sql
+++ b/prisma/migrations/20251204155411_add_cancellation_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "job_application" ADD COLUMN     "cancellationReason" TEXT,
+ADD COLUMN     "cancelledAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -233,6 +233,9 @@ model JobApplication {
   doctorConfirmedAt  DateTime?
   rejectedAt         DateTime?
   rejectionReason    String?
+  // Cancellation fields
+  cancelledAt        DateTime?
+  cancellationReason String?
 
   @@unique([jobId, doctorProfileId])
   @@index([jobId])

--- a/src/app/(main)/profile/history/cancel-application-dialog.tsx
+++ b/src/app/(main)/profile/history/cancel-application-dialog.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle, Loader2, X } from "lucide-react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+	Form,
+	FormControl,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/components/ui/form";
+import { Textarea } from "@/components/ui/textarea";
+import { client } from "@/lib/rpc";
+import type { $Enums } from "../../../../../prisma/generated/prisma/client";
+
+const cancellationSchema = z.object({
+	cancellationReason: z
+		.string()
+		.min(10, "Please provide at least 10 characters")
+		.max(500, "Reason must be less than 500 characters"),
+});
+
+type CancellationFormValues = z.infer<typeof cancellationSchema>;
+
+interface CancelApplicationDialogProps {
+	applicationId: string;
+	jobTitle: string;
+	status: $Enums.JobApplicationStatus;
+}
+
+export function CancelApplicationDialog({
+	applicationId,
+	jobTitle,
+	status,
+}: CancelApplicationDialogProps) {
+	const [open, setOpen] = useState(false);
+	const queryClient = useQueryClient();
+
+	const requiresReason = status === "DOCTOR_CONFIRMED";
+
+	const form = useForm<CancellationFormValues>({
+		resolver: zodResolver(cancellationSchema),
+		defaultValues: {
+			cancellationReason: "",
+		},
+	});
+
+	const cancelMutation = useMutation({
+		mutationFn: async (data?: CancellationFormValues) => {
+			const response = await client.api.v2.doctors.applications[
+				":applicationId"
+			].cancel.$post({
+				param: { applicationId },
+				json: { cancellationReason: data?.cancellationReason },
+			});
+
+			if (!response.ok) {
+				const error = await response.json();
+				throw new Error(error.message || "Failed to cancel application");
+			}
+
+			return response.json();
+		},
+		onSuccess: (data) => {
+			toast.success(data.message || "Application cancelled successfully");
+			setOpen(false);
+			form.reset();
+			// Invalidate and refetch applications
+			queryClient.invalidateQueries({ queryKey: ["doctor-applications"] });
+			// Force page refresh for server component
+			window.location.reload();
+		},
+		onError: (error: Error) => {
+			toast.error(error.message || "Failed to cancel application");
+		},
+	});
+
+	const onSubmit = (data: CancellationFormValues) => {
+		cancelMutation.mutate(data);
+	};
+
+	const handleCancelWithoutReason = () => {
+		cancelMutation.mutate(undefined);
+	};
+
+	return (
+		<AlertDialog open={open} onOpenChange={setOpen}>
+			<AlertDialogTrigger asChild>
+				<Button
+					variant="ghost"
+					size="sm"
+					className="text-red-600 hover:text-red-700 hover:bg-red-50"
+				>
+					<X className="w-3.5 h-3.5 mr-1" />
+					Cancel
+				</Button>
+			</AlertDialogTrigger>
+			<AlertDialogContent className="sm:max-w-md">
+				<AlertDialogHeader>
+					<div className="flex items-center gap-3">
+						<div className="flex h-10 w-10 items-center justify-center rounded-full bg-red-100">
+							<AlertTriangle className="h-5 w-5 text-red-600" />
+						</div>
+						<div>
+							<AlertDialogTitle>Cancel Application</AlertDialogTitle>
+							<AlertDialogDescription className="text-left">
+								{requiresReason
+									? "You have already confirmed this job. Are you sure you want to cancel?"
+									: "Are you sure you want to cancel this application?"}
+							</AlertDialogDescription>
+						</div>
+					</div>
+				</AlertDialogHeader>
+
+				<div className="py-4">
+					<div className="rounded-lg bg-slate-50 p-3 mb-4">
+						<p className="text-sm font-medium text-slate-900">{jobTitle}</p>
+						{requiresReason && (
+							<p className="text-xs text-amber-600 mt-1">
+								⚠️ The employer will be notified of your cancellation
+							</p>
+						)}
+					</div>
+
+					{requiresReason ? (
+						<Form {...form}>
+							<form
+								onSubmit={form.handleSubmit(onSubmit)}
+								className="space-y-4"
+							>
+								<FormField
+									control={form.control}
+									name="cancellationReason"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>
+												Reason for cancellation{" "}
+												<span className="text-red-500">*</span>
+											</FormLabel>
+											<FormControl>
+												<Textarea
+													placeholder="Please explain why you need to cancel this application..."
+													className="min-h-[100px] resize-none"
+													{...field}
+												/>
+											</FormControl>
+											<FormMessage />
+											<p className="text-xs text-slate-500">
+												This will be shared with the employer
+											</p>
+										</FormItem>
+									)}
+								/>
+								<AlertDialogFooter>
+									<AlertDialogCancel
+										type="button"
+										disabled={cancelMutation.isPending}
+									>
+										Keep Application
+									</AlertDialogCancel>
+									<Button
+										type="submit"
+										disabled={cancelMutation.isPending}
+										className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
+									>
+										{cancelMutation.isPending ? (
+											<>
+												<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+												Cancelling...
+											</>
+										) : (
+											"Yes, Cancel Application"
+										)}
+									</Button>
+								</AlertDialogFooter>
+							</form>
+						</Form>
+					) : (
+						<AlertDialogFooter>
+							<AlertDialogCancel disabled={cancelMutation.isPending}>
+								Keep Application
+							</AlertDialogCancel>
+							<AlertDialogAction
+								onClick={(e) => {
+									e.preventDefault();
+									handleCancelWithoutReason();
+								}}
+								disabled={cancelMutation.isPending}
+								className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
+							>
+								{cancelMutation.isPending ? (
+									<>
+										<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+										Cancelling...
+									</>
+								) : (
+									"Yes, Cancel Application"
+								)}
+							</AlertDialogAction>
+						</AlertDialogFooter>
+					)}
+				</div>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/src/app/(main)/profile/history/page.tsx
+++ b/src/app/(main)/profile/history/page.tsx
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import Link from "next/link";
 import { backendApi } from "@/lib/rpc";
 import type { $Enums } from "../../../../../prisma/generated/prisma/client";
+import { CancelApplicationDialog } from "./cancel-application-dialog";
 import ReviewsDialog from "./reviews-dialog";
 
 async function HistoryPage() {
@@ -175,6 +176,9 @@ async function HistoryPage() {
 				{applications.data.map((application) => {
 					const statusBadge = getStatusBadge(application.status);
 					const isCompleted = application.status.toUpperCase() === "COMPLETED";
+					const canCancel =
+						application.status === "PENDING" ||
+						application.status === "DOCTOR_CONFIRMED";
 
 					return (
 						<div
@@ -227,6 +231,13 @@ async function HistoryPage() {
 									>
 										View Details
 									</Link>
+									{canCancel && (
+										<CancelApplicationDialog
+											applicationId={application.id}
+											jobTitle={application.job.title || "Untitled Job"}
+											status={application.status}
+										/>
+									)}
 									{isCompleted && (
 										<ReviewsDialog
 											facilityId={application.job.facility.id}


### PR DESCRIPTION
This pull request adds support for cancelling job applications, including handling different workflows for pending and confirmed applications. It introduces new database fields, backend logic, and a frontend dialog for users to cancel their applications, with special handling and employer notification for confirmed applications.

**Database changes:**

* Added `cancelledAt` and `cancellationReason` fields to the `job_application` table and updated the Prisma schema to support storing cancellation details. [[1]](diffhunk://#diff-30f3aff0dc05282bea7632cbf118742d82153c9c3d6ae15334d252020877e2fcR1-R3) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR236-R238)

**Backend logic:**

* Implemented the `cancelDoctorJobApplication` service method in `doctors.services.ts` to handle cancellation requests. Pending applications are deleted, while confirmed applications require a cancellation reason and trigger employer notifications (currently via console logs as placeholders).
* Added a new API endpoint (`POST /api/v2/doctors/applications/:applicationId/cancel`) to allow doctors to cancel applications, with validation for cancellation reason when required.

**Frontend integration:**

* Added the `CancelApplicationDialog` React component, which provides a UI for cancelling applications, including a reason input when required, and integrates with the backend API.
* Integrated the cancellation dialog into the profile history page, allowing users to cancel applications that are pending or confirmed, and triggering UI updates on success. [[1]](diffhunk://#diff-f38f023fb0826f14b2f1faccec1dfdbfef9a56c0d519a8deecfaa4485804738aR6) [[2]](diffhunk://#diff-f38f023fb0826f14b2f1faccec1dfdbfef9a56c0d519a8deecfaa4485804738aR179-R181) [[3]](diffhunk://#diff-f38f023fb0826f14b2f1faccec1dfdbfef9a56c0d519a8deecfaa4485804738aR234-R240) database and job status reset to OPEN

## Screenshots
<img width="536" height="266" alt="Screenshot 2025-12-05 at 12 33 49 AM" src="https://github.com/user-attachments/assets/ed01d4e1-5617-4d5f-b06f-643c31f4e31f" />

Job cancellation dialog when status in `pending`

<img width="477" height="458" alt="Screenshot 2025-12-05 at 12 35 10 AM" src="https://github.com/user-attachments/assets/6da309d4-26cb-4105-8f27-9ae719a73876" />

Job cancellation when doctor has confirm the job but has to cancel last minute due to emergency etc
